### PR TITLE
Upgrade installCommand for Laravel 5.5

### DIFF
--- a/src/Baum/Console/InstallCommand.php
+++ b/src/Baum/Console/InstallCommand.php
@@ -66,6 +66,15 @@ class InstallCommand extends Command {
     $this->writeModel($name);
 
   }
+  
+  /**
+   * Execute the console command in Laravel 5.5
+   * 
+   * @return void
+   */
+  public function handle(){
+    $this->fire();
+  }
 
   /**
    * Get the command arguments


### PR DESCRIPTION
Laravel 5.5 uses the handle() method instead of fire() in commands.
This PR adds a handle() method that simply calls fire() internally. This way it should be compatible with previous versions of Laravel and the 5.5 series.